### PR TITLE
I18n support for Red Hat Access CFME plugin / engine

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,0 +1,1 @@
+Vmdb::Gettext::Domains.add_domain('RedhatAccessCfme', RedhatAccessCfme::Engine.root.join('locale').to_s, :po)

--- a/config/rh_insights_yaml_strings.rb
+++ b/config/rh_insights_yaml_strings.rb
@@ -1,0 +1,32 @@
+# This is automatically generated file (rake locale:extract_rh_insights_yaml_strings).
+# The file contains strings extracted from various yaml files for gettext to find.
+# TRANSLATORS: file: deploy/menubar/redhat_access_insights_section.yml
+N_("Red Hat Insights")
+# TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_rules.yml
+N_("Rules")
+# TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_systems.yml
+N_("Systems")
+# TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_overview.yml
+N_("Overview")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Red Hat Acess Insights")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Access to Red Hat Access Insights")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Red Hat Access Insights Overview")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Access to Red Hat Access Insights Overview")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Red Hat Access Insights Admin")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Access to Red Hat Access Admin Pages")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Red Hat Access Insights Rules")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Access to Red Hat Access Rules Page")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Red Hat Access Insights Systems")
+# TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+N_("Access to Red Hat Access Systems Page")
+# TRANSLATORS: file: deploy/miq_shortcuts/redhat_access_miq_shortcuts.yml
+N_("Red Hat Access Insights")

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -1,0 +1,58 @@
+namespace :locale do
+  desc "Extract strings from various yaml files and store them in a ruby file for gettext:find"
+  task :extract_rh_insights_yaml_strings do
+    def update_output(string, file, output)
+      return if string.nil? || string.empty?
+      if output.key?(string)
+        output[string].append(file)
+      else
+        output[string] = [file]
+      end
+    end
+
+    def parse_object(object, keys, file, output)
+      if object.kind_of?(Hash)
+        object.keys.each do |key|
+          if keys.include?(key) || keys.include?(key.to_s)
+            if object[key].kind_of?(Array)
+              object[key].each { |i| update_output(i, file, output) }
+            else
+              update_output(object[key], file, output)
+            end
+          end
+          parse_object(object[key], keys, file, output)
+        end
+      elsif object.kind_of?(Array)
+        object.each do |item|
+          parse_object(item, keys, file, output)
+        end
+      end
+    end
+
+    engine_root = RedhatAccessCfme::Engine.root.to_s
+    yamls = {
+      "deploy/menubar/*.yml"              => %w(name),
+      "deploy/miq_product_features/*.yml" => %w(name description),
+      "deploy/miq_shortcuts/*.yml"        => %w(description)
+    }
+    output = {}
+
+    yamls.keys.each do |yaml_glob|
+      Dir.glob("#{engine_root}/#{yaml_glob}").each do |file|
+        yml = YAML.load_file(file)
+        parse_object(yml, yamls[yaml_glob], file.gsub("#{engine_root}/", ""), output)
+      end
+    end
+
+    File.open("#{engine_root}/config/rh_insights_yaml_strings.rb", "w+") do |f|
+      f.puts "# This is automatically generated file (rake locale:extract_rh_insights_yaml_strings)."
+      f.puts "# The file contains strings extracted from various yaml files for gettext to find."
+      output.keys.each do |key|
+        output[key].sort.uniq.each do |file|
+          f.puts "# TRANSLATORS: file: #{file}"
+        end
+        f.puts 'N_("%s")' % key
+      end
+    end
+  end
+end

--- a/locale/RedhatAccessCfme.pot
+++ b/locale/RedhatAccessCfme.pot
@@ -1,0 +1,102 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the RedhatAccessCfme package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: RedhatAccessCfme 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-21 15:13+0200\n"
+"PO-Revision-Date: 2016-09-21 15:13+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:22
+msgid "Access to Red Hat Access Admin Pages"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:14
+msgid "Access to Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:18
+msgid "Access to Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:26
+msgid "Access to Red Hat Access Rules Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:30
+msgid "Access to Red Hat Access Systems Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_overview.yml
+#: ../config/rh_insights_yaml_strings.rb:10
+msgid "Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_shortcuts/redhat_access_miq_shortcuts.yml
+#: ../config/rh_insights_yaml_strings.rb:32
+msgid "Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:20
+msgid "Red Hat Access Insights Admin"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:16
+msgid "Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:24
+msgid "Red Hat Access Insights Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:28
+msgid "Red Hat Access Insights Systems"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+#: ../config/rh_insights_yaml_strings.rb:12
+msgid "Red Hat Acess Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_section.yml
+#: ../config/rh_insights_yaml_strings.rb:4
+msgid "Red Hat Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_rules.yml
+#: ../config/rh_insights_yaml_strings.rb:6
+msgid "Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_systems.yml
+#: ../config/rh_insights_yaml_strings.rb:8
+msgid "Systems"
+msgstr ""
+
+#: ../app/views/redhat_access_cfme/insights/index.html.haml:16
+msgid "This appliance is not registered to Red Hat."
+msgstr ""
+
+#: ../app/views/redhat_access_cfme/insights/index.html.haml:22
+msgid "To use Red Hat Insights, the appliance must be registered to Red Hat Subscription Management  or Satellite (version 6.1 or newer)."
+msgstr ""

--- a/locale/en/RedhatAccessCfme.po
+++ b/locale/en/RedhatAccessCfme.po
@@ -1,0 +1,84 @@
+# English translations for RedhatAccessCfme package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the RedhatAccessCfme package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: RedhatAccessCfme 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-09-21 15:14+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Admin Pages"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Rules Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Systems Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_overview.yml
+msgid "Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_shortcuts/redhat_access_miq_shortcuts.yml
+msgid "Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Admin"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Systems"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Acess Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_section.yml
+msgid "Red Hat Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_rules.yml
+msgid "Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_systems.yml
+msgid "Systems"
+msgstr ""
+
+msgid "This appliance is not registered to Red Hat."
+msgstr ""
+
+msgid "To use Red Hat Insights, the appliance must be registered to Red Hat Subscription Management  or Satellite (version 6.1 or newer)."
+msgstr ""

--- a/locale/ja/RedhatAccessCfme.po
+++ b/locale/ja/RedhatAccessCfme.po
@@ -1,0 +1,84 @@
+# Japanese translations for RedhatAccessCfme package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the RedhatAccessCfme package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: RedhatAccessCfme 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-09-21 15:13+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Admin Pages"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Rules Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Systems Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_overview.yml
+msgid "Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_shortcuts/redhat_access_miq_shortcuts.yml
+msgid "Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Admin"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Systems"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Acess Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_section.yml
+msgid "Red Hat Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_rules.yml
+msgid "Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_systems.yml
+msgid "Systems"
+msgstr ""
+
+msgid "This appliance is not registered to Red Hat."
+msgstr ""
+
+msgid "To use Red Hat Insights, the appliance must be registered to Red Hat Subscription Management  or Satellite (version 6.1 or newer)."
+msgstr ""

--- a/locale/zh_CN/RedhatAccessCfme.po
+++ b/locale/zh_CN/RedhatAccessCfme.po
@@ -1,0 +1,84 @@
+# Chinese translations for RedhatAccessCfme package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the RedhatAccessCfme package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: RedhatAccessCfme 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-09-21 15:14+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Admin Pages"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Rules Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Access to Red Hat Access Systems Page"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_overview.yml
+msgid "Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_shortcuts/redhat_access_miq_shortcuts.yml
+msgid "Red Hat Access Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Admin"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Overview"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Access Insights Systems"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/miq_product_features/redhat_access_miq_product_features.yml
+msgid "Red Hat Acess Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_section.yml
+msgid "Red Hat Insights"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_rules.yml
+msgid "Rules"
+msgstr ""
+
+#. TRANSLATORS: file: deploy/menubar/redhat_access_insights_item_systems.yml
+msgid "Systems"
+msgstr ""
+
+msgid "This appliance is not registered to Red Hat."
+msgstr ""
+
+msgid "To use Red Hat Insights, the appliance must be registered to Red Hat Subscription Management  or Satellite (version 6.1 or newer)."
+msgstr ""


### PR DESCRIPTION
Implemented:
- New rake task to extract strings from yaml files, the strings are then stored in a ruby file
- The plugin registers its gettext catalog with ManageIQ
- New set of catalogs for the plugin created by `rake gettext:find`
