### PR TITLE
Engine initializers should not run after build_middleware_stack

### DIFF
--- a/lib/redhat_access_cfme/engine.rb
+++ b/lib/redhat_access_cfme/engine.rb
@@ -2,7 +2,7 @@ module RedhatAccessCfme
   class Engine < ::Rails::Engine
     isolate_namespace RedhatAccessCfme
     
-    initializer "redhat_access.mount_engine", :after => :build_middleware_stack do |app|
+    initializer "redhat_access.mount_engine" do |app|
       app.config.assets.paths << "#{RedhatAccessCfme::Engine.root}/vendor/assets/images"
       app.config.assets.paths << "#{RedhatAccessCfme::Engine.root}/vendor/assets/stylesheets"
       app.config.assets.paths << "#{RedhatAccessCfme::Engine.root}/vendor/assets/fonts"


### PR DESCRIPTION
This is causing an error when loading the rails environment in the latest
cfme builds.

Specifically because this could cause other engine initializers to
also run after build_middleware_stack. If any other initializer tries
to edit the list of middlewares then an error will be raised such as the
following:

```plain
rails aborted!
can't modify frozen Array
/opt/rh/cfme-gemset/gems/actionpack-5.0.7/lib/action_dispatch/middleware/stack.rb:97:in `push'
/opt/rh/cfme-gemset/gems/actionpack-5.0.7/lib/action_dispatch/middleware/stack.rb:97:in `use'
/opt/rh/cfme-gemset/bundler/gems/cfme-graphql-5f68621f2791/lib/manageiq/graphql/engine.rb:27:in `block in <class:Engine>'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/initializable.rb:30:in `instance_exec'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/initializable.rb:30:in `run'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/initializable.rb:56:in `block in run_initializers'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/initializable.rb:54:in `run_initializers'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/application.rb:352:in `initialize!'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/railtie.rb:193:in `public_send'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/railtie.rb:193:in `method_missing'
/var/www/miq/vmdb/config/environment.rb:5:in `<top (required)>'
/opt/rh/cfme-gemset/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:293:in `require'
/opt/rh/cfme-gemset/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:293:in `block in require'
/opt/rh/cfme-gemset/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:259:in `load_dependency'
/opt/rh/cfme-gemset/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:293:in `require'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/application.rb:328:in `require_environment!'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/application.rb:448:in `block in run_tasks_blocks'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/commands/rake_proxy.rb:14:in `block in run_rake_task'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/commands/rake_proxy.rb:11:in `run_rake_task'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/commands/commands_tasks.rb:51:in `run_command!'
/opt/rh/cfme-gemset/gems/railties-5.0.7/lib/rails/commands.rb:18:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => environment
```

Also see the following spec in rails which ensures that Engine initializers
are run *before* build_middleware_stack:

https://github.com/rails/rails/blob/v5.0.7/railties/test/railties/engine_test.rb#L488-L507

@lphiri @Fryguy 